### PR TITLE
Add windows support

### DIFF
--- a/lib/Terminal/Getpass.pm6
+++ b/lib/Terminal/Getpass.pm6
@@ -1,9 +1,17 @@
 use v6.c;
 unit module Terminal::Getpass:ver<0.0.3>;
 
-use Term::termios;
-
 sub getpass(Str $prompt = "Password: ", IO::Handle $stream = $*ERR --> Str) is export {
+    if $*DISTRO.is-win {
+        win-getpass($prompt);
+    } else {
+        unix-getpass($prompt, $stream);
+    }
+}
+
+my sub unix-getpass(Str $prompt!, IO::Handle $stream! --> Str) {
+    use Term::termios;
+
     my $old := Term::termios.new(fd => 1).getattr;
     my $new := Term::termios.new(fd => 1).getattr;
 
@@ -20,6 +28,31 @@ sub getpass(Str $prompt = "Password: ", IO::Handle $stream = $*ERR --> Str) is e
     }
     $old.setattr(:DRAIN);
     $stream.say: "";
+    $phrase;
+}
+
+my sub win-getpass(Str $prompt!, IO::Handle $stream? --> Str) {
+    use NativeCall;
+
+    my sub _getch returns uint8 is native('msvcrt') { * }
+    my sub _putch(uint8) is native('msvcrt') { * }
+
+    _putch($_.ord) for $prompt.comb;
+    my Str $phrase = "";
+
+    loop {
+        my Int $c = _getch;
+
+        last if so $c == any("\r".ord, "\n".ord);
+        die if $c == 3;
+        if $c == "\b".ord {
+            $phrase = $phrase.chop
+        } else {
+            $phrase ~= $c.chr;
+        }
+    }
+    _putch("\r".ord);
+    _putch("\n".ord);
     $phrase;
 }
 


### PR DESCRIPTION
Manually tested on windows PC:
```
>perl6 -e "use Terminal::Getpass; my $pass = getpass; say $pass;"
Password:
abcd
```

version:
```
>perl6 --version
This is Rakudo Star version 2017.10 built on MoarVM version 2017.10
implementing Perl 6.c.
```