### PR TITLE
Hotfix for Unicode input

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,9 @@ Revision history for Terminal-Getpass
 
 {{$NEXT}}
 
+0.0.10 2022-07-12T14:09:39+02:00
+   - Read Unicode characters completely, before trying to decode them as utf-8
+
 0.0.9  2021-02-14T13:16:21+09:00
    - Exit by Ctrl-C returns the same code as prompt does
 

--- a/META6.json
+++ b/META6.json
@@ -22,5 +22,5 @@
   ],
   "test-depends": [
   ],
-  "version": "0.0.9"
+  "version": "0.0.10"
 }

--- a/lib/Terminal/Getpass.pm6
+++ b/lib/Terminal/Getpass.pm6
@@ -23,7 +23,8 @@ my sub unix-getpass(Str $prompt!, IO::Handle $stream! --> Str) {
     $stream.print: $prompt;
     my Str $phrase = "";
     loop {
-        my $c = $*IN.read(1);
+        my $c = buf8.new;
+        $c.append($*IN.read(1)) until try $c.decode('utf-8');
         last if $c.decode("utf-8") ~~ /\n/;
         if $c.unpack("C*") == 3 {
             $old.setattr(:DRAIN);


### PR DESCRIPTION
Hello,

this is a proposed quick solution; I needed to get the module working for myself so I might as well share it.

The idea is that the reading should continue until the decode attempt succeeds - if it does succeed, it won't be an empty string and therefore it will pass as a truthy value.